### PR TITLE
Fix window status activity

### DIFF
--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -98,6 +98,8 @@ if-shell '[ `echo "if( $TMUX_VER < 2.1 ){ 1 }" | bc` ]' \
 # {{{ window status style
 setw -g window-status-style fg=default,bg=default
 setw -g window-status-current-style fg=black,bg=colour248
+setw -g window-status-activity-attr none
+setw -g window-status-activity-style fg=colour220
 # }}}
 # {{{ window status format
 setw -g window-status-format ' #I:#W#F '


### PR DESCRIPTION
When window activity was detected, the window would
be higlighted with a white background and blue foreground
and it looked like the same as the current window selection.
I changed this to just turn the text yellow for windows that
have activity detected.