### PR TITLE
Fix mouse support

### DIFF
--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -80,19 +80,7 @@ set -g monitor-activity on
 set -g visual-activity on
 # }}}
 # {{{ Mouse support
-# Setup mouse for tmux versions greater than or equal to 2.4
-if-shell '[ `echo "if( $TMUX_VER >= 2.4 ){ 1 }" | bc` ]'  \
-    "set -g mouse on"
-# Setup mouse for tmux versions less than 2.4 and greater or equal to 2.1
-if-shell '[ `echo "if( $TMUX_VER < 2.4 ){if( $TMUX_VER >= 2.1 ){ 1 }}" | bc` ]' \
-    "set -g mouse-utf8 on; \
-     set -g mouse on"
-# Setup mouse for all tmux versions less than 2.1
-if-shell '[ `echo "if( $TMUX_VER < 2.1 ){ 1 }" | bc` ]' \
-    "set -g mode-mouse on; \
-     set -g mouse-resize-pane on; \
-     set -g mouse-select-pane on; \
-     set -g mouse-select-window on"
+set -g mouse on
 # }}}
 ## Window Options
 # {{{ window status style


### PR DESCRIPTION
I had three 'if-shell' blocks to setup mouse support for tmux <= 2.4
Since tmux is now in version 3.x I removed these blocks since they rely
on the 'bc' command, if it is not installed, mouse support was not
activated. The fix was to just assume the tmux is >= 2.4